### PR TITLE
Add acc-provision role to support acc-provision operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM quay.io/operator-framework/ansible-operator:v1.3.0
+
+COPY requirements.yml ${HOME}/requirements.yml
+USER 0
+# TBD: No need to use proxy anymore once we move to build it in the jenkins I think?
+ENV http_proxy=http://proxy.esl.cisco.com:80
+ENV https_proxy=http://proxy.esl.cisco.com:80
+RUN update-crypto-policies --set LEGACY && pip3 install pyopenssl
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
+RUN yum install git -y
+RUN git clone --single-branch --branch newacioperator https://github.com/noironetworks/acc-provision.git
+RUN cd acc-provision/provision && python3 setup.py install
+
+USER 1001
+ENV http_proxy=''
+ENV https_proxy=''
+
+COPY watches.yaml ${HOME}/watches.yaml
+COPY roles/ ${HOME}/roles/
+COPY playbooks/ ${HOME}/playbooks/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+# Current Operator version
+VERSION ?= 0.0.1
+# Default bundle image tag
+BUNDLE_IMG ?= controller-bundle:$(VERSION)
+# Options for 'bundle-build'
+ifneq ($(origin CHANNELS), undefined)
+BUNDLE_CHANNELS := --channels=$(CHANNELS)
+endif
+ifneq ($(origin DEFAULT_CHANNEL), undefined)
+BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
+endif
+BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+
+# Image URL to use all building/pushing image targets
+IMG ?= controller:latest
+
+all: docker-build
+
+# Run against the configured Kubernetes cluster in ~/.kube/config
+run: ansible-operator
+	$(ANSIBLE_OPERATOR) run
+
+install1: kustomize
+	$(KUSTOMIZE) build config/crd >> deploy/crd.yaml
+
+# Install CRDs into a cluster
+install: kustomize
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+
+# Uninstall CRDs from a cluster
+uninstall: kustomize
+	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+
+# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+#
+deploy1: kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default >> deploy/all.yaml
+deploy: kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+# Undeploy controller in the configured Kubernetes cluster in ~/.kube/config
+undeploy: kustomize
+	$(KUSTOMIZE) build config/default | kubectl delete -f -
+
+# Build the docker image
+docker-build:
+	docker build . -t ${IMG}
+
+# Push the docker image
+docker-push:
+	docker push ${IMG}
+
+PATH  := $(PATH):$(PWD)/bin
+SHELL := env PATH=$(PATH) /bin/sh
+OS    = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
+OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')
+ARCHOPER = $(shell uname -m )
+
+kustomize:
+ifeq (, $(shell which kustomize 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p bin ;\
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_$(OS)_$(ARCH).tar.gz | tar xzf - -C bin/ ;\
+	}
+KUSTOMIZE=$(realpath ./bin/kustomize)
+else
+KUSTOMIZE=$(shell which kustomize)
+endif
+
+ansible-operator:
+ifeq (, $(shell which ansible-operator 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p bin ;\
+	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.3.0/ansible-operator-v1.3.0-$(ARCHOPER)-$(OSOPER) ;\
+	mv ansible-operator-v1.3.0-$(ARCHOPER)-$(OSOPER) ./bin/ansible-operator ;\
+	chmod +x ./bin/ansible-operator ;\
+	}
+ANSIBLE_OPERATOR=$(realpath ./bin/ansible-operator)
+else
+ANSIBLE_OPERATOR=$(shell which ansible-operator)
+endif
+
+# Generate bundle manifests and metadata, then validate generated files.
+.PHONY: bundle
+bundle: kustomize
+	operator-sdk generate kustomize manifests -q
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	operator-sdk bundle validate ./bundle
+
+# Build the bundle image.
+.PHONY: bundle-build
+bundle-build:
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .

--- a/PROJECT
+++ b/PROJECT
@@ -1,0 +1,8 @@
+domain: accprov
+layout: ansible.sdk.operatorframework.io/v1
+projectName: acc-provision-operator
+resources:
+- group: aci
+  kind: AccProvision
+  version: v1alpha1
+version: 3-alpha

--- a/bin/ansible-operator
+++ b/bin/ansible-operator
@@ -1,0 +1,1 @@
+Not Found

--- a/config/crd/bases/aci.accprov_accprovisions.yaml
+++ b/config/crd/bases/aci.accprov_accprovisions.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accprovisions.aci.accprov
+spec:
+  group: aci.accprov
+  names:
+    kind: AccProvision
+    listKind: AccProvisionList
+    plural: accprovisions
+    singular: accprovision
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AccProvision is the Schema for the accprovisions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of AccProvision
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of AccProvision
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/aci.accprov_accprovisions.yaml
+# +kubebuilder:scaffold:crdkustomizeresource

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,26 @@
+# Adds namespace to all resources.
+namespace: acc-provision-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: acc-provision-operator-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patchesStrategicMerge:
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+- manager_auth_proxy_patch.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,26 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+        - "--leader-election-id=acc-provision-operator"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: noirolabs/acc-provision-operator
+  newTag: apootest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - name: manager
+          args:
+            - "--enable-leader-election"
+            - "--leader-election-id=acc-provision-operator"
+          env:
+            - name: ANSIBLE_GATHERING
+              value: explicit
+          image: controller:latest
+      terminationGracePeriodSeconds: 10
+      hostNetwork: true

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,0 +1,16 @@
+---
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/config/rbac/accprovision_editor_role.yaml
+++ b/config/rbac/accprovision_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit accprovisions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: accprovision-editor-role
+rules:
+- apiGroups:
+  - aci.accprov
+  resources:
+  - accprovisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aci.accprov
+  resources:
+  - accprovisions/status
+  verbs:
+  - get

--- a/config/rbac/accprovision_viewer_role.yaml
+++ b/config/rbac/accprovision_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view accprovisions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: accprovision-viewer-role
+rules:
+- apiGroups:
+  - aci.accprov
+  resources:
+  - accprovisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aci.accprov
+  resources:
+  - accprovisions/status
+  verbs:
+  - get

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,25 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+  ##
+  ## Base operator rules
+  ##
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - pods
+      - pods/exec
+      - pods/log
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  ##
+  ## Rules for aci.accprov/v1alpha1, Kind: AccProvision
+  ##
+  - apiGroups:
+      - aci.accprov
+    resources:
+      - accprovisions
+      - accprovisions/status
+      - accprovisions/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+# +kubebuilder:scaffold:rules

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/samples/aci_v1alpha1_accprovision.yaml
+++ b/config/samples/aci_v1alpha1_accprovision.yaml
@@ -1,0 +1,8 @@
+apiVersion: aci.accprov/v1alpha1
+kind: AccProvision
+metadata:
+  name: accprovision-sample
+  namespace: aci-containers-system
+spec:
+  acc_provision_input:
+    deployment_operator: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,4 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- aci_v1alpha1_accprovision.yaml
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+# +kubebuilder:scaffold:patchesJson6902

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/config/testing/debug_logs_patch.yaml
+++ b/config/testing/debug_logs_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: ANSIBLE_DEBUG_LOGS
+              value: "TRUE"

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -1,0 +1,23 @@
+# Adds namespace to all resources.
+namespace: osdk-test
+
+namePrefix: osdk-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+patchesStrategicMerge:
+- manager_image.yaml
+- debug_logs_patch.yaml
+- ../default/manager_auth_proxy_patch.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+images:
+- name: testing
+  newName: testing-operator

--- a/config/testing/manager_image.yaml
+++ b/config/testing/manager_image.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: testing

--- a/config/testing/pull_policy/Always.yaml
+++ b/config/testing/pull_policy/Always.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Always

--- a/config/testing/pull_policy/IfNotPresent.yaml
+++ b/config/testing/pull_policy/IfNotPresent.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: IfNotPresent

--- a/config/testing/pull_policy/Never.yaml
+++ b/config/testing/pull_policy/Never.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Never

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -1,0 +1,225 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: acc-provision-operator-leader-election-role
+  namespace: aci-containers-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acc-provision-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aci.accprov
+  resources:
+  - accprovisions
+  - accprovisions/status
+  - accprovisions/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acc-provision-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acc-provision-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: acc-provision-operator-leader-election-rolebinding
+  namespace: aci-containers-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: acc-provision-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: aci-containers-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acc-provision-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acc-provision-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: aci-containers-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acc-provision-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acc-provision-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: aci-containers-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: acc-provision-operator-controller-manager-metrics-service
+  namespace: aci-containers-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: acc-provision-operator-controller-manager
+  namespace: aci-containers-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --leader-election-id=acc-provision-operator
+        env:
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ACI_CERT_PATH
+          value: /usr/local/etc/aci-cert/
+        - name: FLAVOR
+          value: kubernetes-1.19
+        image: noirolabs/acc-provision-operator:apootest1
+        name: manager
+        volumeMounts:
+        - mountPath: /usr/local/etc/aci-cert/
+          name: aci-user-cert-volume
+      hostNetwork: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            defaultMode: 420
+            secretName: aci-user-cert

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,0 +1,116 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accprovisions.aci.accprov
+spec:
+  group: aci.accprov
+  names:
+    kind: AccProvision
+    listKind: AccProvisionList
+    plural: accprovisions
+    singular: accprovision
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AccProvision is the Schema for the accprovisions API
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              acc_provision_input:
+                type: object
+                properties:
+                  aci_config:
+                    type: object
+                    properties:
+                      cluster_tenant:
+                        type: string
+                      sync_login:
+                        type: object
+                        properties:
+                          certfile:
+                            type: string
+                          keyfile:
+                            type: string
+                      client_ssl:
+                        type: boolean
+                  net_config:
+                    type: object
+                    properties:
+                      interface_mtu:
+                        type: integer
+                      service_monitor_interval:
+                        type: integer
+                      pbr_tracking_non_snat:
+                        type: boolean
+                  registry:
+                    type: object
+                    properties:
+                      image_prefix:
+                        type: string
+                      image_pull_secret:
+                        type: string
+                      aci_containers_controller_version:
+                        type: string
+                      aci_containers_host_version:
+                        type: string
+                      aci_containers_operator_version:
+                        type: string
+                      cnideploy_version:
+                        type: string
+                      opflex_agent_version:
+                        type: string
+                      openvswitch_version:
+                        type: string
+                      gbp_version:
+                        type: string
+                  logging:
+                    type: object
+                    properties:
+                      controller_log_level:
+                        type: string
+                      hostagent_log_level:
+                        type: string
+                      opflexagent_log_level:
+                        type: string
+                  istio_config:
+                    type: object
+                    properties:
+                      install_istio:
+                        type: boolean
+                      install_profile:
+                        type: string
+                  multus:
+                    type: object
+                    properties:
+                      disable:
+                        type: boolean
+                  drop_log_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  kube_config:
+                    type: object
+                    properties:
+                      ovs_memory_limit:
+                        type: string
+                      use_external_service_ip_allocator:
+                        type: boolean
+                      use_privileged_containers:
+                        type: boolean
+                      use_openshift_security_context_constraints:
+                        type: boolean
+                      allow_kube_api_default_epg:
+                        type: boolean
+                      image_pull_policy:
+                        type: string
+                      reboot_opflex_with_ovs:
+                        type: boolean
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - community.kubernetes
+
+  tasks:
+    - name: Create Namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+
+    - import_tasks: kustomize.yml
+      vars:
+        state: present

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -1,0 +1,6 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks: []

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - community.kubernetes
+
+  tasks:
+    - import_tasks: kustomize.yml
+      vars:
+        state: absent
+
+    - name: Destroy Namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+        state: absent
+
+    - name: Unset pull policy
+      command: '{{ kustomize }} edit remove patch pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/molecule/default/kustomize.yml
+++ b/molecule/default/kustomize.yml
@@ -1,0 +1,15 @@
+---
+- name: Build kustomize testing overlay
+  # load_restrictor must be set to none so we can load patch files from the default overlay
+  command: '{{ kustomize }} build  --load_restrictor none .'
+  args:
+    chdir: '{{ config_dir }}/testing'
+  register: resources
+  changed_when: false
+
+- name: Set resources to {{ state }}
+  k8s:
+    definition: '{{ item }}'
+    state: '{{ state }}'
+    wait: yes
+  loop: '{{ resources.stdout | from_yaml_all | list }}'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+platforms:
+  - name: cluster
+    groups:
+      - k8s
+provisioner:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+    host_vars:
+      localhost:
+        ansible_python_interpreter: '{{ ansible_playbook_python }}'
+        config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config
+        samples_dir: ${MOLECULE_PROJECT_DIRECTORY}/config/samples
+        operator_image: ${OPERATOR_IMAGE:-""}
+        operator_pull_policy: ${OPERATOR_PULL_POLICY:-"Always"}
+        kustomize: ${KUSTOMIZE_PATH:-kustomize}
+  env:
+    K8S_AUTH_KUBECONFIG: ${KUBECONFIG:-"~/.kube/config"}
+verifier:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Ensure operator image is set
+      fail:
+        msg: |
+          You must specify the OPERATOR_IMAGE environment variable in order to run the
+          'default' scenario
+      when: not operator_image
+
+    - name: Set testing image
+      command: '{{ kustomize }} edit set image testing={{ operator_image }}'
+      args:
+        chdir: '{{ config_dir }}/testing'
+
+    - name: Set pull policy
+      command: '{{ kustomize }} edit add patch pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'
+
+    - name: Set testing namespace
+      command: '{{ kustomize }} edit set namespace {{ namespace }}'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/molecule/default/tasks/accprovision_test.yml
+++ b/molecule/default/tasks/accprovision_test.yml
@@ -1,0 +1,19 @@
+---
+- name: Create the aci.accprov/v1alpha1.AccProvision
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"
+    wait: yes
+    wait_timeout: 300
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"
+  vars:
+    cr_file: 'aci_v1alpha1_accprovision.yaml'
+
+- name: Add assertions here
+  assert:
+    that: false
+    fail_msg: FIXME Add real assertions for your operator

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,57 @@
+---
+- name: Verify
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - community.kubernetes
+
+  vars:
+    ctrl_label: control-plane=controller-manager
+
+  tasks:
+    - block:
+        - name: Import all test files from tasks/
+          include_tasks: '{{ item }}'
+          with_fileglob:
+            - tasks/*_test.yml
+      rescue:
+        - name: Retrieve relevant resources
+          k8s_info:
+            api_version: '{{ item.api_version }}'
+            kind: '{{ item.kind }}'
+            namespace: '{{ namespace }}'
+          loop:
+            - api_version: v1
+              kind: Pod
+            - api_version: apps/v1
+              kind: Deployment
+            - api_version: v1
+              kind: Secret
+            - api_version: v1
+              kind: ConfigMap
+          register: debug_resources
+
+        - name: Retrieve Pod logs
+          k8s_log:
+            name: '{{ item.metadata.name }}'
+            namespace: '{{ namespace }}'
+            container: manager
+          loop: "{{ q('k8s', api_version='v1', kind='Pod', namespace=namespace, label_selector=ctrl_label) }}"
+          register: debug_logs
+
+        - name: Output gathered resources
+          debug:
+            var: debug_resources
+
+        - name: Output gathered logs
+          debug:
+            var: item.log_lines
+          loop: '{{ debug_logs.results }}'
+
+        - name: Re-emit failure
+          vars:
+            failed_task:
+              result: '{{ ansible_failed_result }}'
+          fail:
+            msg: '{{ failed_task }}'

--- a/molecule/kind/converge.yml
+++ b/molecule/kind/converge.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - name: Build operator image
+      docker_image:
+        build:
+          path: '{{ project_dir }}'
+          pull: no
+        name: '{{ operator_image }}'
+        tag: latest
+        push: no
+        source: build
+        force_source: yes
+
+    - name: Load image into kind cluster
+      command: kind load docker-image --name osdk-test '{{ operator_image }}'
+      register: result
+      changed_when: '"not yet present" in result.stdout'
+
+- import_playbook: ../default/converge.yml

--- a/molecule/kind/create.yml
+++ b/molecule/kind/create.yml
@@ -1,0 +1,8 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Create test kind cluster
+      command: kind create cluster --name osdk-test --kubeconfig {{ kubeconfig }}

--- a/molecule/kind/destroy.yml
+++ b/molecule/kind/destroy.yml
@@ -1,0 +1,16 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - community.kubernetes
+
+  tasks:
+    - name: Destroy test kind cluster
+      command: kind delete cluster --name osdk-test --kubeconfig {{ kubeconfig }}
+
+    - name: Unset pull policy
+      command: '{{ kustomize }} edit remove patch pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+platforms:
+  - name: cluster
+    groups:
+      - k8s
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../default/prepare.yml
+    verify: ../default/verify.yml
+  lint: |
+    set -e
+    ansible-lint
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+    host_vars:
+      localhost:
+        ansible_python_interpreter: '{{ ansible_playbook_python }}'
+        config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config
+        samples_dir: ${MOLECULE_PROJECT_DIRECTORY}/config/samples
+        project_dir: ${MOLECULE_PROJECT_DIRECTORY}
+        operator_image: testing-operator
+        operator_pull_policy: "Never"
+        kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+        kustomize: ${KUSTOMIZE_PATH:-kustomize}
+  env:
+    K8S_AUTH_KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
+    KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
+verifier:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.kubernetes
+    version: "<1.0.0"
+  - operator_sdk.util

--- a/roles/accprovision/README.md
+++ b/roles/accprovision/README.md
@@ -1,0 +1,43 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance,
+if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in 
+defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables 
+that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set
+for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for
+users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/accprovision/defaults/main.yml
+++ b/roles/accprovision/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for AccProvision
+acc_provision_dir_path: /tmp/acc_provision
+aci_operator_config_path: /usr/local/etc/aci-containers/spec
+acc_provision_file_name: acc_provision_input.yaml
+acicnioperator_cr: cr.yaml

--- a/roles/accprovision/handlers/main.yml
+++ b/roles/accprovision/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for AccProvision

--- a/roles/accprovision/meta/main.yml
+++ b/roles/accprovision/meta/main.yml
@@ -1,0 +1,64 @@
+---
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/roles/accprovision/scripts/process_string_to_yaml.py
+++ b/roles/accprovision/scripts/process_string_to_yaml.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import json
+import yaml
+import copy
+import os
+
+def main():
+    cmap_input_path = os.getenv('CONFIGMAP_INPUT_FILE')
+    cmap = dict()
+    input_dict = dict()
+    with open(cmap_input_path, 'r') as stream:
+        cmap = yaml.safe_load(stream)
+        yaml_cmap_intermediate = cmap['data']['spec']
+        input_dict = yaml.safe_load(yaml_cmap_intermediate)
+        yaml_cmap = input_dict['acc_provision_input']
+    crd_input = os.getenv('CRDINPUT')
+    yaml_crd = yaml.safe_load(crd_input)
+    deep_merge(yaml_crd, yaml_cmap)
+
+    # Write configmap file
+    input_dict['acc_provision_input'] = yaml_crd
+    cmap['data']['spec'] = json.dumps(input_dict)
+    cmap['metadata'].pop('managedFields', None)
+    cmap['metadata'].pop('annotations', None)
+    cmap['metadata'].pop('creationTimestamp', None)
+    cmap['metadata'].pop('resourceVersion', None)
+    cmap['metadata'].pop('uid', None)
+    with open(cmap_input_path, 'w') as outfile:
+        json.dump(cmap, outfile)
+
+    # Write acc_provision_input to file
+    acc_prov_dir = os.getenv('ACCPROVDIR')
+    acc_prov_file = os.getenv('ACCPROVFILE')
+    acc_prov_file_path = os.path.join(acc_prov_dir, acc_prov_file)
+    with open(acc_prov_file_path, 'w') as outfile:
+        yaml.dump(yaml_crd, outfile, default_flow_style=False)
+    return 0
+
+def deep_merge(override, default):
+    if isinstance(override, dict) and isinstance(default, dict):
+        for k, v in default.items():
+            if k not in override:
+                override[k] = v
+            else:
+                override[k] = deep_merge(override[k], v)
+    return copy.deepcopy(override)
+
+if __name__ == "__main__":
+    main()

--- a/roles/accprovision/tasks/main.yml
+++ b/roles/accprovision/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+- name: Create temporary directory for acc-provision run
+  file:
+    path: "{{ acc_provision_dir_path }}"
+    state: directory
+    mode: '0777'
+
+- name: Get acc-provision configmap
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: acc-provision-config
+    namespace: "{{ lookup('env', 'WATCH_NAMESPACE') }}"
+  register: cmap_data
+
+- name: Set fact
+  set_fact:
+    cmap_content: "{{ cmap_data['resources'][0]}}"
+
+- name: Write cmap YAML
+  copy:
+    dest: "{{ acc_provision_dir_path }}/cmap.yaml"
+    content: "{{ cmap_content }}"
+
+- name: Set input YAML
+  set_fact:
+    cmap_input: "{{ web_service['resources'][0]['data']['spec'] }}"
+
+- name: Compute acc-provision input file
+  script: "scripts/process_string_to_yaml.py"
+  args:
+    executable: /usr/bin/python3
+  environment:
+    CRDINPUT: "{{ acc_provision_input }}"
+    ACI_OPERATOR_CONFIG_PATH: "{{ aci_operator_config_path }}"
+    CONFIGMAP_INPUT_FILE: "{{ acc_provision_dir_path }}/cmap.yaml"
+    ACCPROVDIR: "{{ acc_provision_dir_path }}"
+    ACCPROVFILE: "{{ acc_provision_file_name }}"
+
+- name: Delete the configmap
+  k8s:
+    state: absent
+    api_version: v1
+    kind: ConfigMap
+    name: acc-provision-config
+    namespace: "{{ lookup('env', 'WATCH_NAMESPACE') }}"
+    wait: yes
+
+- name: Create new configmap
+  k8s:
+    state: present
+    force: yes
+    src: "{{ acc_provision_dir_path }}/cmap.yaml"
+
+- name: Generate acicnioperator CR
+  shell: "acc-provision -c {{ acc_provision_file_name }} -f {{ lookup('env', 'ACC_PROVISION_FLAVOR') }} -r {{ acicnioperator_cr }} --operator-mode True"
+  args:
+    chdir: "{{ acc_provision_dir_path }}"
+
+- name: Run k8s command to apply acicnioperator CR
+  k8s:
+    state: present
+    src: "{{ acc_provision_dir_path }}/{{ acicnioperator_cr }}"
+
+- name: Delete acioperator cr file
+  file:
+    path: "{{ acc_provision_dir_path }}/{{ acicnioperator_cr }}"
+    state: absent

--- a/roles/accprovision/vars/main.yml
+++ b/roles/accprovision/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for AccProvision

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,0 +1,8 @@
+---
+# Use the 'create api' subcommand to add watches to this file.
+- version: v1alpha1
+  group: aci.ctrl
+  kind: AccProvisionInput
+  role: accprovision
+  snakeCaseParameters: false
+# +kubebuilder:scaffold:watch


### PR DESCRIPTION
Relevant files:
1. watches.yaml: Tells the operator which CRD to watch for
2. requirements.yaml: External Ansible libraries required
3. Dockerfile: Change acc-provision branch name here according to release
4. roles/acc-provision: Business logic which defines what tasks run when CR updates happen

