### PR TITLE
Change the acc-provision configmap creation

### DIFF
--- a/roles/accprovision/scripts/process_string_to_yaml.py
+++ b/roles/accprovision/scripts/process_string_to_yaml.py
@@ -21,19 +21,6 @@ def main():
     crd_definition = yaml.safe_load(crd_definition) 
     deep_merge(yaml_crd, yaml_cmap, crd_definition)
 
-    # Write configmap file
-    input_dict['acc_provision_input'] = yaml_crd
-    cmap['data']['spec'] = json.dumps(input_dict)
-    cmap['metadata'].pop('managedFields', None)
-    cmap['metadata'].pop('annotations', None)
-    cmap['metadata'].pop('creationTimestamp', None)
-    cmap['metadata'].pop('resourceVersion', None)
-    cmap['metadata'].pop('uid', None)
-    cmap['metadata'].pop('selfLink', None)
-    with open(cmap_input_path, 'w') as outfile:
-        json.dump(cmap, outfile)
-
-    # Write acc_provision_input to file
     acc_prov_file_path = os.path.join(os.getenv('ACCPROVDIR'), os.getenv('ACCPROVFILE'))
     with open(acc_prov_file_path, 'w') as outfile:
         yaml.dump(yaml_crd, outfile, default_flow_style=False)

--- a/roles/accprovision/tasks/process.yaml
+++ b/roles/accprovision/tasks/process.yaml
@@ -56,13 +56,6 @@
   pause:
     seconds: 20
 
-- name: Create new configmap
-  k8s:
-    state: present
-    force: yes
-    src: "{{ acc_provision_dir_path }}/cmap.yaml"
-    wait: yes
-
 - name: Generate new deployment yaml
   shell: "acc-provision -c {{ acc_provision_file_name }} -f {{ lookup('env', 'ACC_PROVISION_FLAVOR') }} -o {{ aci_cni_deployment_file }} --operator-mode True"
   args:
@@ -72,3 +65,7 @@
   k8s:
     state: present
     src: "{{ acc_provision_dir_path }}/{{ aci_cni_deployment_file }}"
+
+- name: Wait 20s for sync
+  pause:
+    seconds: 20


### PR DESCRIPTION
Instead of creating the config map as part of separate task, now create it as part of the CNI deployment file, along with acc-provision-input CRD