### PR TITLE
Using tags instead of branch name to perform git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM quay.io/operator-framework/ansible-operator:v1.10.1
-ARG ACC_PROVISION_REPO_BRANCH
-ENV ACC_PROVISION_BRANCH=${ACC_PROVISION_REPO_BRANCH:-master}
-
+ARG ACC_PROVISION_REPO_TAG
+ENV ACC_PROVISION_TAG=${ACC_PROVISION_REPO_TAG}
 # Export http and https proxy here if building locally for dev
 COPY requirements.yml ${HOME}/requirements.yml
 USER 0
@@ -9,7 +8,7 @@ RUN update-crypto-policies --set LEGACY && pip3 install pyopenssl
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 RUN yum install git -y
-RUN git clone --single-branch --branch ${ACC_PROVISION_BRANCH} https://github.com/noironetworks/acc-provision.git
+RUN git clone --single-branch --branch ${ACC_PROVISION_TAG} https://github.com/noironetworks/acc-provision.git
 RUN cd acc-provision/provision && python3 setup.py install
 
 USER 1001


### PR DESCRIPTION
We need the corresponding change in containertest and container release jobs for arguments like below:
--build-arg ACC_PROVISION_REPO_TAG=$aci_containers_repo_tag.  where tag being viz. 5.2.3