### PR TITLE
Update ansible-operator image tag to latest in order for health index…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.15.0
+FROM quay.io/operator-framework/ansible-operator:latest
 ARG ACC_PROVISION_REPO_BRANCH
 ENV ACC_PROVISION_BRANCH=${ACC_PROVISION_REPO_BRANCH:-master}
 # Required OpenShift Labels


### PR DESCRIPTION
… check to pass for container certification tooling

(cherry picked from commit b7a82d7899bb6373979e0bdf7dc427ecfdf472cd)