### PR TITLE
Adding fix for urllib http+unix issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN update-crypto-policies --set LEGACY && \
    pip3 install --upgrade pyyaml && \
    pip3 install setuptools-rust && \
    pip3 install pyopenssl && \
-   pip3 install --upgrade 'urllib3<1.27' requests
+   pip3 install requests==2.31.0 && \
+   pip3 install --upgrade 'urllib3<1.27'
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 RUN yum install git -y


### PR DESCRIPTION
Because of requests lib updated in base image, the current urllib http+unix package was unsupported with newer version. As such pinning the requests version to 2.31 resolves the compatibility.