### PR TITLE
Fix trivy installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
       if: tag IS present
       install:
         - pip3 install docker molecule openshift jmespath pytz
+        - curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
       before_script:
         - export DOCKER_BUILDKIT=1
         - export UPSTREAM_ID=81c2369


### PR DESCRIPTION
To fix the trivy command not found issues, adding in install step of travis.yaml